### PR TITLE
Upstream changes from Goost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ GDScript/
 Node2D.gd
 Node2D.tscn
 Resources/
+
+# Config
+classes.txt

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -272,12 +272,19 @@ func get_list_of_available_classes(must_be_instantable : bool = true, allow_edit
 	var classes : Array = []
 	full_class_list.sort()
 	
-	var classes_from_config : Array = []
+	var custom_classes : Array = []
 	var file = File.new()
 	if file.file_exists("res://classes.txt"):
 		file.open("res://classes.txt", File.READ)
 		while !file.eof_reached():
-			classes_from_config.push_back(file.get_line())
+			var cname = file.get_line()
+			var internal_cname = "_" + cname
+			# The declared class may not exist, and it may be exposed as `_ClassName` rather than `ClassName`.
+			if !ClassDB.class_exists(cname) && !ClassDB.class_exists(internal_cname):
+				continue
+			if ClassDB.class_exists(internal_cname):
+				cname = internal_cname
+			custom_classes.push_back(cname)
 		file.close()
 
 	for name_of_class in full_class_list:
@@ -294,7 +301,7 @@ func get_list_of_available_classes(must_be_instantable : bool = true, allow_edit
 		if name_of_class.find("Editor") != -1 && (regression_test_project || !allow_editor):
 			continue
 
-		if !classes_from_config.empty() and !(name_of_class in classes_from_config):
+		if !custom_classes.empty() and !(name_of_class in custom_classes):
 			continue
 
 		if !must_be_instantable || ClassDB.can_instance(name_of_class):

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -180,9 +180,6 @@ var function_exceptions : Array = [
 	# TODO: these take too long to execute, does not make sense to limit number of iterations ether.
 	"smooth_polyline_approx",
 	"smooth_polygon_approx",
-	# TODO: infinite spam of errors
-	"stamp_rect",
-	"blend_rect",
 ]
 
 # Globally disabled classes which causes bugs or are very hard to us

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -180,6 +180,9 @@ var function_exceptions : Array = [
 	# TODO: these take too long to execute, does not make sense to limit number of iterations ether.
 	"smooth_polyline_approx",
 	"smooth_polygon_approx",
+	# TODO: infinite spam of errors
+	"stamp_rect",
+	"blend_rect",
 ]
 
 # Globally disabled classes which causes bugs or are very hard to us

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -175,6 +175,11 @@ var function_exceptions : Array = [
 	"add_child",
 	"add_child_below_node",
 	"add_sibling",
+
+	# Goost
+	# TODO: these take too long to execute, does not make sense to limit number of iterations ether.
+	"smooth_polyline_approx",
+	"smooth_polygon_approx",
 ]
 
 # Globally disabled classes which causes bugs or are very hard to us

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -6,19 +6,6 @@ var regression_test_project : bool = false # Set it to true in RegressionTestPro
 
 # Globablly disabled functions for all classes
 var function_exceptions : Array = [
-	# GODEX
-	"smooth_polygon_approx", # _Geometry
-	"smooth_polyline_approx", 
-	"stamp_rect",# ImageBlender
-	"get_centroid",
-	"get_pixelv_or_null",
-	"replace_color",
-	"rotate_180",
-	"rotate_90",
-	"blend_rect",
-	"_iter_init",
-	"save_gif",
-	
 	# Dommy Rasterizer
 	"set_data", # ImageTexture
 	"set_YCbCr_imgs", # CameraFeed
@@ -206,9 +193,6 @@ var disabled_classes : Array = [
 	"_Thread",
 	"_Semaphore",
 	"_Mutex",
-	
-	#GOOST
-	"_GoostImage", # TODO, for now heavily crashing
 ]
 var variant_exceptions : Array =  [
 	# TODO

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -264,7 +264,9 @@ func remove_disabled_methods(method_list : Array, exceptions : Array) -> void:
 			method_list.remove(index)
 
 func remove_thing(thing : Object) -> void:
-	if not is_instance_valid(thing):
+	if !thing:
+		return
+	if !is_instance_valid(thing):
 		return
 	if thing is Node:
 		thing.queue_free()

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -267,10 +267,6 @@ func remove_disabled_methods(method_list : Array, exceptions : Array) -> void:
 			method_list.remove(index)
 
 func remove_thing(thing : Object) -> void:
-	if !thing:
-		return
-	if !is_instance_valid(thing):
-		return
 	if thing is Node:
 		thing.queue_free()
 	elif thing is Object && !(thing is Reference):

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -286,6 +286,14 @@ func get_list_of_available_classes(must_be_instantable : bool = true, allow_edit
 	var classes : Array = []
 	full_class_list.sort()
 	
+	var classes_from_config : Array = []
+	var file = File.new()
+	if file.file_exists("res://classes.txt"):
+		file.open("res://classes.txt", File.READ)
+		while !file.eof_reached():
+			classes_from_config.push_back(file.get_line())
+		file.close()
+
 	for name_of_class in full_class_list:
 		if name_of_class in disabled_classes:
 			continue
@@ -299,11 +307,13 @@ func get_list_of_available_classes(must_be_instantable : bool = true, allow_edit
 			continue
 		if name_of_class.find("Editor") != -1 && (regression_test_project || !allow_editor):
 			continue
-			
-			
+
+		if !classes_from_config.empty() and !(name_of_class in classes_from_config):
+			continue
+
 		if !must_be_instantable || ClassDB.can_instance(name_of_class):
 			classes.push_back(name_of_class)
-			
+
 #	classes = classes.slice(0, 200)
 	
 	print(str(classes.size()) + " choosen classes from all " + str(full_class_list.size()) + " classes.")

--- a/Autoloads/BasicData.gd
+++ b/Autoloads/BasicData.gd
@@ -275,6 +275,8 @@ func remove_disabled_methods(method_list : Array, exceptions : Array) -> void:
 			method_list.remove(index)
 
 func remove_thing(thing : Object) -> void:
+	if not is_instance_valid(thing):
+		return
 	if thing is Node:
 		thing.queue_free()
 	elif thing is Object && !(thing is Reference):

--- a/FunctionExecutor.gd
+++ b/FunctionExecutor.gd
@@ -93,7 +93,12 @@ func tests_all_functions() -> void:
 						print(to_print)
 
 					var ret = object.callv(method_data["name"], arguments)
-					BasicData.remove_thing(ret)
+
+					if !BasicData.regression_test_project:
+						if ret != null && ret is Object:
+							if !(ret.get_class() in BasicData.disabled_classes) && \
+									!(ret.get_class() in ["PhysicsDirectSpaceStateSW", "Physics2DDirectSpaceStateSW"]):
+								BasicData.remove_thing(ret)
 
 					for argument in arguments:
 						BasicData.remove_thing(argument)

--- a/FunctionExecutor.gd
+++ b/FunctionExecutor.gd
@@ -92,7 +92,8 @@ func tests_all_functions() -> void:
 						to_print += ")"
 						print(to_print)
 
-					object.callv(method_data["name"], arguments)
+					var ret = object.callv(method_data["name"], arguments)
+					BasicData.remove_thing(ret)
 
 					for argument in arguments:
 						BasicData.remove_thing(argument)


### PR DESCRIPTION
Closes #2.

1. `classes.txt` file can be created at project root containing a list of classes to fuzz. Each class must start from a new line. Qarminer still skips excluded classes such as `Server` or `Editor` regardless of custom classes.
2. Cleanup return value from `object.callv(method_data["name"], arguments)`, which caused a memory leak from `PolyBoolean2D.boolean_polygons_tree()` function in Goost (returns `PolyNode2D` used to represent polygon hierarchy in this case, which inherits from `Node2D`).
3. Removed most Goost-specific exceptions now, because fixed, except `smooth_polyline/polygon_approx`, not sure what's the best way to prevent number of iterations yet, and `ImageBlender` issues which I delegated to fix by original author: https://github.com/goostengine/goost/issues/120#issuecomment-891938737. Ideally, it would also be nice to configure a list of excluded functions in Qarminer just like classes, I guess.

FYI, I've created https://github.com/goostengine/goost-fuzzer which acts like Qarminer, except I clone the repository via GitHub Actions. Once this PR is merged, I'll get back to using `qarmin/Qarminer` repository rather than forked `goostengine/Qarminer` which has these enhancements and fixes.