### PR TITLE
Fix bullet crash

### DIFF
--- a/FunctionExecutor.gd
+++ b/FunctionExecutor.gd
@@ -96,8 +96,12 @@ func tests_all_functions() -> void:
 
 					if !BasicData.regression_test_project:
 						if ret != null && ret is Object:
-							if !(ret.get_class() in BasicData.disabled_classes) && \
-									!(ret.get_class() in ["PhysicsDirectSpaceStateSW", "Physics2DDirectSpaceStateSW"]):
+							var disabled_return_classes = [
+								"PhysicsDirectSpaceStateSW", 
+								"Physics2DDirectSpaceStateSW", 
+								"BulletPhysicsDirectSpaceState",
+							]
+							if !(ret.get_class() in BasicData.disabled_classes) && !(ret.get_class() in disabled_return_classes):
 								BasicData.remove_thing(ret)
 
 					for argument in arguments:


### PR DESCRIPTION
Follow up to #3, I've forgot that I disable bullet module to speed up compilation in Goost, so I couldn't check this...

Makes me wonder whether it may be worth adding `get_direct_space_state()` to exception list instead? In any case, this seems to fix the crash.

By the way, it may be worth to restrict pull requests CI checks to one workflow. If something fails, I get tons of email notifications. Good punishment, though. :smiley: